### PR TITLE
fix(chart): harden defaults and add Artifact Hub README

### DIFF
--- a/charts/kreuzberg/Chart.yaml
+++ b/charts/kreuzberg/Chart.yaml
@@ -20,6 +20,7 @@ keywords:
   - rust
 maintainers:
   - name: kreuzberg-dev
+    email: naaman@kreuzberg.dev
     url: https://github.com/kreuzberg-dev
 icon: https://raw.githubusercontent.com/kreuzberg-dev/kreuzberg-lts/main/docs/assets/logo.svg
 annotations:

--- a/charts/kreuzberg/README.md
+++ b/charts/kreuzberg/README.md
@@ -1,0 +1,64 @@
+# Kreuzberg Helm Chart
+
+Deploy the [Kreuzberg](https://kreuzberg.dev) document-intelligence API server on Kubernetes. Kreuzberg extracts text, tables, metadata, and images from 91+ document formats — PDF, Office, images (with OCR), HTML, email, and archives — via a Rust core.
+
+> **Kreuzberg v4 is the legacy LTS line.** The current version is [Xberg](https://github.com/xberg-io/xberg) (v5+), where all new features land. Use this chart when you deploy Kreuzberg v4; v4 receives critical bug and security fixes through the end of 2026. See the [LTS policy](https://docs.kreuzberg.dev/lts/).
+
+## Install
+
+The chart is published as an OCI artifact on GitHub Container Registry. Installing without `--version` pulls the latest release:
+
+```bash
+helm install kreuzberg oci://ghcr.io/kreuzberg-dev/charts/kreuzberg
+```
+
+Pin a version and target a namespace:
+
+```bash
+helm install kreuzberg oci://ghcr.io/kreuzberg-dev/charts/kreuzberg \
+  --version 4.10.1 --namespace kreuzberg --create-namespace
+```
+
+The API server is exposed through a `ClusterIP` service on port 80. Port-forward to reach it locally; endpoints are documented in the [API Server guide](https://docs.kreuzberg.dev/guides/api-server/):
+
+```bash
+kubectl port-forward svc/kreuzberg 8000:80
+```
+
+## Configuration
+
+Override values with `--set key=value` or a `-f my-values.yaml` file.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `replicaCount` | `1` | Number of replicas. Keep at 1 with `ReadWriteOnce` cache storage (see Scaling). |
+| `strategy.type` | `Recreate` | Deployment strategy. `Recreate` avoids Multi-Attach errors with an RWO cache volume. |
+| `image.registry` | `ghcr.io` | Image registry. |
+| `image.repository` | `kreuzberg-dev/kreuzberg-full` | Image repository — the `full` variant, with OCR and all optional dependencies. |
+| `image.tag` | `""` | Image tag. Defaults to the chart `appVersion` when empty. |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy. |
+| `service.type` | `ClusterIP` | Service type. |
+| `service.port` | `80` | Service port. |
+| `resources.requests` | `512Mi` / `500m` | Memory / CPU requests. |
+| `resources.limits` | `2Gi` / `2000m` | Memory / CPU limits. |
+| `autoscaling.enabled` | `false` | Enable a HorizontalPodAutoscaler. |
+| `autoscaling.minReplicas` / `maxReplicas` | `1` / `10` | HPA replica bounds. |
+| `ingress.enabled` | `false` | Enable an Ingress. |
+| `cache.enabled` | `true` | Mount a PVC for OCR models and downloaded assets. When disabled, an ephemeral `emptyDir` is used instead. |
+| `cache.size` | `2Gi` | Cache PVC size. |
+| `cache.accessModes` | `[ReadWriteOnce]` | Cache PVC access modes. Use `ReadWriteMany` before scaling replicas. |
+| `podDisruptionBudget.enabled` | `false` | Enable a PodDisruptionBudget. |
+| `kreuzberg.logLevel` | `info` | Log level. |
+| `kreuzberg.ocrLanguage` | `eng` | Default Tesseract OCR language. |
+
+The pod runs as non-root (UID 1000) with a read-only root filesystem and all Linux capabilities dropped. `enableServiceLinks` is disabled by default: a release named `kreuzberg` would otherwise inject a `KREUZBERG_PORT` service-discovery variable that the binary rejects.
+
+### Scaling
+
+`cache.accessModes: [ReadWriteOnce]` lets only one node mount the cache PVC at a time. To run more than one replica, either switch `cache.accessModes` to `ReadWriteMany` (with storage that supports it) or disable the persistent cache (`cache.enabled=false`, which re-fetches models per pod). With RWO storage, keep `strategy.type: Recreate`.
+
+## Links
+
+- [Documentation](https://kreuzberg.dev)
+- [Kubernetes guide](https://docs.kreuzberg.dev/guides/kubernetes/)
+- [Source](https://github.com/kreuzberg-dev/kreuzberg-lts)

--- a/charts/kreuzberg/templates/deployment.yaml
+++ b/charts/kreuzberg/templates/deployment.yaml
@@ -8,6 +8,10 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "kreuzberg.selectorLabels" . | nindent 6 }}
@@ -25,15 +29,21 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kreuzberg.serviceAccountName" . }}
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.cache.enabled }}
+      {{- if and .Values.cache.enabled .Values.cache.initChown }}
       initContainers:
         - name: init-cache
           image: busybox:1.37-glibc
           command: ['sh', '-c', 'mkdir -p /app/.kreuzberg && chown -R 1000:1000 /app/.kreuzberg']
           securityContext:
             runAsUser: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              add: ["CHOWN"]
+              drop: ["ALL"]
           volumeMounts:
             - name: cache
               mountPath: /app/.kreuzberg
@@ -88,18 +98,21 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            {{- if .Values.cache.enabled }}
+            # The cache directory is always mounted from a writable volume (PVC
+            # when cache.enabled, ephemeral emptyDir otherwise) so HF_HOME and
+            # KREUZBERG_CACHE_DIR stay writable under a read-only root filesystem.
             - name: cache
               mountPath: /app/.kreuzberg
-            {{- end }}
             - name: tmp
               mountPath: /tmp
       volumes:
-        {{- if .Values.cache.enabled }}
         - name: cache
+          {{- if .Values.cache.enabled }}
           persistentVolumeClaim:
             claimName: {{ include "kreuzberg.fullname" . }}-cache
-        {{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         - name: tmp
           emptyDir: {}
       {{- with .Values.nodeSelector }}

--- a/charts/kreuzberg/values.yaml
+++ b/charts/kreuzberg/values.yaml
@@ -1,9 +1,20 @@
-replicaCount: 2
+# -- Number of replicas.
+# WARNING: When cache.enabled=true and cache.accessModes=[ReadWriteOnce], only one
+# replica can mount the PVC at a time. Keep replicaCount: 1 with RWO storage, or
+# switch to ReadWriteMany storage before increasing replicas. With RWO + multiple
+# replicas the deployment strategy must be Recreate (not RollingUpdate).
+replicaCount: 1
+
+# -- Deployment strategy. When cache is enabled with ReadWriteOnce storage,
+# set to Recreate to avoid Multi-Attach errors during rolling updates.
+strategy:
+  type: Recreate
 
 image:
   registry: ghcr.io
   repository: kreuzberg-dev/kreuzberg-full
-  tag: "latest"
+  # -- Image tag. Defaults to Chart.AppVersion when empty.
+  tag: ""
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -57,7 +68,7 @@ resources:
 
 autoscaling:
   enabled: false
-  minReplicas: 2
+  minReplicas: 1
   maxReplicas: 10
   targetCPUUtilizationPercentage: 80
 
@@ -75,11 +86,25 @@ kreuzberg:
   ocrLanguage: "eng"
 
 cache:
+  # -- Enable a persistent cache (PVC) for embedding models and downloaded assets.
+  # When disabled, an ephemeral emptyDir is mounted at the cache directory instead,
+  # so the cache path stays writable under a read-only root filesystem (models are
+  # simply re-fetched per pod).
   enabled: true
   size: 2Gi
   storageClass: ""
   accessModes:
     - ReadWriteOnce
+  # -- Run an init container to chown the cache directory to UID 1000. Most
+  # block-backed storage classes honour fsGroup on mount and do not need it;
+  # set true for NFS or storage that does not.
+  initChown: true
+
+# -- Disable Kubernetes service-discovery environment variable injection.
+# A release named "kreuzberg" would inject KREUZBERG_PORT=tcp://<ip>:<port>,
+# which the binary parses as a u16 and panics on. CoreDNS makes these
+# variables unnecessary in all modern clusters.
+enableServiceLinks: false
 
 podDisruptionBudget:
   enabled: false

--- a/poly.toml
+++ b/poly.toml
@@ -523,3 +523,7 @@ commit = { stages = ["commit-msg"] }
 [hooks.pre-commit.commands.pyrefly]
 run = "pyrefly check packages/python"
 files = "packages/python/**/*.py"
+
+[hooks.pre-commit.commands.helm]
+run = "bash -c 'helm lint --strict charts/kreuzberg && helm template charts/kreuzberg | kubeconform -strict -summary -'"
+files = "charts/**"


### PR DESCRIPTION
Hardens the Helm chart deployment defaults and completes the Artifact Hub listing.

- Single-replica default with `strategy: Recreate` and a ReadWriteOnce cache PVC, avoiding Multi-Attach errors on rolling updates; pin the image tag to `appVersion` (empty `image.tag`) instead of `latest`; writable HF_HOME cache path.
- Point the chart image at the renamed `ghcr.io/kreuzberg-dev/kreuzberg-full` package (the old `kreuzberg-dev/kreuzberg` was retired) and add the maintainer email so Artifact Hub shows the org maintainer.
- Add `charts/kreuzberg/README.md`, which `helm package` bundles and Artifact Hub renders as the package page (OCI install, values reference, security context, RWO cache scaling constraint).

`ah lint` and `helm lint` both pass with zero errors.