### PR TITLE
fix: read legacy DOC CLX from correct FIB pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Legacy DOC piece-table lookup** now reads `fcClx`/`lcbClx` from the correct FIB pair, preventing compressed Windows-1252 text from falling back to UTF-16LE contiguous decoding.
+
 ## [4.10.0] - 2026-07-11
 
 First release of the standalone **Kreuzberg v4 LTS** line. This is the long-term-support home for

--- a/crates/kreuzberg/src/extraction/doc/mod.rs
+++ b/crates/kreuzberg/src/extraction/doc/mod.rs
@@ -8,6 +8,12 @@
 use crate::error::{KreuzbergError, Result};
 use std::io::Cursor;
 
+/// Zero-based pair index of fcClx/lcbClx in FibRgFcLcb97.
+///
+/// See [MS-DOC] section 2.5.6:
+/// <https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-doc/0c9df81f-98d0-454e-ad84-b612cd05b1a4>
+const CLX_PAIR_INDEX: usize = 33;
+
 /// Result of DOC text extraction.
 pub struct DocExtractionResult {
     /// Extracted text content.
@@ -116,10 +122,14 @@ fn extract_text_word97(word_doc: &[u8], table_stream: &[u8]) -> Result<String> {
         return Err(KreuzbergError::parsing("FIB too short for cbRgFcLcb"));
     }
 
-    let _ = u16::from_le_bytes([word_doc[cbrgfclcb_offset], word_doc[cbrgfclcb_offset + 1]]) as usize;
+    let cb_rg_fc_lcb = u16::from_le_bytes([word_doc[cbrgfclcb_offset], word_doc[cbrgfclcb_offset + 1]]) as usize;
     let rg_fc_lcb_offset = cbrgfclcb_offset + 2;
 
-    let fc_clx_offset = rg_fc_lcb_offset + 66 * 8;
+    if cb_rg_fc_lcb <= CLX_PAIR_INDEX {
+        return extract_text_contiguous(word_doc, ccp_text);
+    }
+
+    let fc_clx_offset = rg_fc_lcb_offset + CLX_PAIR_INDEX * 8;
     let lcb_clx_offset = fc_clx_offset + 4;
 
     if word_doc.len() < lcb_clx_offset + 4 {
@@ -672,5 +682,34 @@ mod tests {
     fn test_extract_doc_invalid_magic() {
         let result = extract_doc_text(b"not a doc file");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_extract_word97_reads_clx_from_fib_rg_fc_lcb97_pair_33() {
+        let mut word_doc = vec![0_u8; 900];
+        word_doc[32..34].copy_from_slice(&14_u16.to_le_bytes());
+        word_doc[62..64].copy_from_slice(&22_u16.to_le_bytes());
+        word_doc[76..80].copy_from_slice(&1_u32.to_le_bytes());
+
+        let rg_fc_lcb_offset = 154;
+        word_doc[152..154].copy_from_slice(&34_u16.to_le_bytes());
+        let clx_pair_offset = rg_fc_lcb_offset + 33 * 8;
+        word_doc[clx_pair_offset..clx_pair_offset + 4].copy_from_slice(&8_u32.to_le_bytes());
+        word_doc[clx_pair_offset + 4..clx_pair_offset + 8].copy_from_slice(&21_u32.to_le_bytes());
+
+        let text_offset = 800_usize;
+        word_doc[text_offset] = 0xE9;
+
+        let mut table_stream = vec![0_u8; 29];
+        table_stream[8] = 0x02;
+        table_stream[9..13].copy_from_slice(&16_u32.to_le_bytes());
+        table_stream[13..17].copy_from_slice(&0_u32.to_le_bytes());
+        table_stream[17..21].copy_from_slice(&1_u32.to_le_bytes());
+        let compressed_fc = 0x4000_0000_u32 | (text_offset as u32 * 2);
+        table_stream[23..27].copy_from_slice(&compressed_fc.to_le_bytes());
+
+        let text = extract_text_word97(&word_doc, &table_stream).expect("failed to read synthetic Word 97 text");
+
+        assert_eq!(text, "é");
     }
 }

--- a/docs-site/src/content/docs/changelog.md
+++ b/docs-site/src/content/docs/changelog.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Legacy DOC piece-table lookup** now reads `fcClx`/`lcbClx` from the correct FIB pair, preventing compressed Windows-1252 text from falling back to UTF-16LE contiguous decoding.
+
 ## [4.10.0] - 2026-07-11
 
 First release of the standalone **Kreuzberg v4 LTS** line. This is the long-term-support home for


### PR DESCRIPTION
## Related

- Microsoft [MS-DOC: FibRgFcLcb97](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-doc/0c9df81f-98d0-454e-ad84-b612cd05b1a4)
- Microsoft [MS-DOC: Retrieving Text](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-doc/01d5d8c4-cf9c-4ef9-80fd-439e763cfe01)

## Description

Fix legacy Word 97-2003 documents whose compressed Windows-1252 text was returned as CJK-looking mojibake.

`FibRgFcLcb97` stores `fcClx`/`lcbClx` as zero-based pair 33. The extractor treated the 66 preceding 32-bit fields as 66 eight-byte pairs, so it read pair 66 instead. In affected documents that produced zero offsets and sent extraction through the contiguous-text fallback, where the byte layout was misclassified as UTF-16LE.

This PR:

- names and uses the specification-defined CLX pair index;
- validates that `cbRgFcLcb` contains that pair before reading it;
- adds a synthetic, non-identifying regression that exercises compressed CP1252 text at pair 33; and
- documents the fix in both changelog sources.

The original private document was used only for local verification and is not included. After the change it extracts with zero CJK mojibake.

### Validation

- RED before the fix: the synthetic test failed with `No text content found in DOC file`.
- `cargo test -p kreuzberg --lib --no-default-features --features office,tokio-runtime extraction::doc::tests` — 8 passed.
- `cargo fmt --all -- --check` — passed.
- Relevant-feature Clippy with `-D warnings` — passed.
- Full relevant-feature library run — 1,602 passed; four unrelated DOCX page-break tests fail identically on untouched `origin/main`.

### Scope

The equivalent lookup also exists in the v5 successor and can receive a separate focused follow-up. This PR is intentionally limited to the v4 LTS runtime.

This contribution was prepared with AI assistance and independently reviewed before submission, following the repository's contribution policy.

## Checklist

- [ ] CI passing
- [x] Tests added where applicable
