### PR TITLE
fix: restore CSV header-value rendering, fix DOCX nested lists and stale formatting tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **CSV extraction dropped its header-value embedding-quality rendering.** `content` fell back to a flat, space-separated table dump instead of the `Row N:` / `Header: Value` pairs added for embedding/search quality, after CSV was migrated onto the generic `InternalDocument`+`Table` pipeline. Restored in `crates/kreuzberg/src/extractors/csv.rs`.
+- **DOCX nested lists rendered flat, with no indentation.** Word nests list items under a single `numId` and uses `w:ilvl` to mark depth, but `build_internal_document` only opened a new list container on `numId` changes and ignored `ilvl` entirely — every level under one list collapsed into a single unindented list. Fixed with a level-tracking stack in `crates/kreuzberg/src/extractors/docx.rs`.
+
 ## [4.10.3] - 2026-09-05
 
 ### Fixed

--- a/crates/kreuzberg/src/extractors/csv.rs
+++ b/crates/kreuzberg/src/extractors/csv.rs
@@ -113,15 +113,18 @@ impl DocumentExtractor for CsvExtractor {
             },
         };
 
+        // The table itself carries the raw grid for programmatic consumers (`doc.tables`,
+        // below); `content` instead gets header-value pairs so cell values keep their
+        // semantic association with column names for embedding/search quality, rather
+        // than the flat space-separated text a plain table render would produce.
+        let content_text = build_content_text(&table.cells, has_header);
+
         let mut builder = InternalDocumentBuilder::new("csv");
-        let cloned_table = Table {
-            cells: table.cells.clone(),
-            markdown: table.markdown.clone(),
-            page_number: table.page_number,
-            bounding_box: table.bounding_box,
-        };
-        builder.push_table(cloned_table, None, None);
+        if !content_text.is_empty() {
+            builder.push_paragraph(&content_text, Vec::new(), None, None);
+        }
         let mut doc = builder.build();
+        doc.tables.push(table);
         doc.mime_type = Cow::Owned(mime_type.to_string());
 
         doc.metadata = Metadata {
@@ -390,6 +393,52 @@ fn infer_column_types(rows: &[Vec<String>], has_header: bool) -> Vec<String> {
             }
         })
         .collect()
+}
+
+/// Build text content with header-value pairs for embedding quality.
+///
+/// When a header row is detected, produces `Row N:\n  Header: Value` pairs
+/// that preserve the semantic association between column names and cell values.
+/// Empty cells are skipped. Falls back to space-separated values when no
+/// header is detected.
+fn build_content_text(rows: &[Vec<String>], has_header: bool) -> String {
+    if rows.is_empty() {
+        return String::new();
+    }
+
+    if !has_header || rows.len() < 2 {
+        return rows
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .map(|cell| cell.trim())
+                    .filter(|cell| !cell.is_empty())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            })
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+
+    let headers = &rows[0];
+    let mut sections = Vec::with_capacity(rows.len() - 1);
+
+    for (i, row) in rows[1..].iter().enumerate() {
+        let mut lines = vec![format!("Row {}:", i + 1)];
+        for (header, value) in headers.iter().zip(row.iter()) {
+            let h = header.trim();
+            let v = value.trim();
+            if !h.is_empty() && !v.is_empty() {
+                lines.push(format!("  {}: {}", h, v));
+            }
+        }
+        if lines.len() > 1 {
+            sections.push(lines.join("\n"));
+        }
+    }
+
+    sections.join("\n\n")
 }
 
 /// Build a Markdown table from parsed rows.

--- a/crates/kreuzberg/src/extractors/docx.rs
+++ b/crates/kreuzberg/src/extractors/docx.rs
@@ -287,8 +287,11 @@ fn build_internal_document(doc: &crate::extraction::docx::parser::Document) -> I
 
     let mut builder = InternalDocumentBuilder::new("docx");
 
-    let mut current_list_numbering_id: Option<i64> = None;
-    let mut current_list_ordered: bool = false;
+    // (numbering_id, ilvl, ordered) for each currently open nested list, outermost first.
+    // Word nests list items under one numId by incrementing `w:ilvl`, not by starting a
+    // new numId per level, so tracking numId alone (as this used to) collapsed every
+    // level under the same list into one flat, unindented list (#5).
+    let mut list_stack: Vec<(i64, i64, bool)> = Vec::new();
 
     for element in &doc.elements {
         match element {
@@ -298,9 +301,8 @@ fn build_internal_document(doc: &crate::extraction::docx::parser::Document) -> I
                 let (text, annotations, math_formulas) = collect_run_annotations(&paragraph.runs);
 
                 if text.is_empty() && math_formulas.is_empty() {
-                    if current_list_numbering_id.is_some() {
+                    while list_stack.pop().is_some() {
                         builder.end_list();
-                        current_list_numbering_id = None;
                     }
                     continue;
                 }
@@ -317,9 +319,8 @@ fn build_internal_document(doc: &crate::extraction::docx::parser::Document) -> I
                 });
 
                 let element_idx: Option<u32> = if let Some(level) = heading_level {
-                    if current_list_numbering_id.is_some() {
+                    while list_stack.pop().is_some() {
                         builder.end_list();
-                        current_list_numbering_id = None;
                     }
                     let heading_text = if text.is_empty() {
                         paragraph.runs_to_markdown()
@@ -332,9 +333,8 @@ fn build_internal_document(doc: &crate::extraction::docx::parser::Document) -> I
                     }
                     Some(idx)
                 } else if is_quote_style {
-                    if current_list_numbering_id.is_some() {
+                    while list_stack.pop().is_some() {
                         builder.end_list();
-                        current_list_numbering_id = None;
                     }
                     builder.push_quote_start();
                     let para_idx = builder.push_paragraph(&text, annotations.clone(), None, None);
@@ -345,29 +345,41 @@ fn build_internal_document(doc: &crate::extraction::docx::parser::Document) -> I
                         builder.push_formula(formula, None, None);
                     }
                     if !text.is_empty() {
-                        let is_ordered = paragraph
-                            .numbering_id
-                            .zip(paragraph.numbering_level)
-                            .and_then(|(nid, nlvl)| doc.numbering_defs.get(&(nid, nlvl)))
+                        let nlvl = paragraph.numbering_level.unwrap_or(0);
+                        let is_ordered = doc
+                            .numbering_defs
+                            .get(&(nid, nlvl))
                             .is_some_and(|lt| *lt == crate::extraction::docx::parser::ListType::Numbered);
-                        if current_list_numbering_id != Some(nid) {
-                            if current_list_numbering_id.is_some() {
+
+                        // Close nested lists deeper than this item's level.
+                        while list_stack.last().is_some_and(|&(_, top_level, _)| top_level > nlvl) {
+                            list_stack.pop();
+                            builder.end_list();
+                        }
+
+                        let same_list = list_stack
+                            .last()
+                            .is_some_and(|&(top_nid, top_level, _)| top_nid == nid && top_level == nlvl);
+
+                        if !same_list {
+                            // A different list starting at a depth already open: close it first.
+                            if list_stack.last().is_some_and(|&(_, top_level, _)| top_level == nlvl) {
+                                list_stack.pop();
                                 builder.end_list();
                             }
                             builder.push_list(is_ordered);
-                            current_list_numbering_id = Some(nid);
-                            current_list_ordered = is_ordered;
+                            list_stack.push((nid, nlvl, is_ordered));
                         }
-                        let li_idx =
-                            builder.push_list_item(&text, current_list_ordered, annotations.clone(), None, None);
+
+                        let current_ordered = list_stack.last().map(|&(_, _, ordered)| ordered).unwrap_or(is_ordered);
+                        let li_idx = builder.push_list_item(&text, current_ordered, annotations.clone(), None, None);
                         Some(li_idx)
                     } else {
                         None
                     }
                 } else {
-                    if current_list_numbering_id.is_some() {
+                    while list_stack.pop().is_some() {
                         builder.end_list();
-                        current_list_numbering_id = None;
                     }
                     for formula in &math_formulas {
                         builder.push_formula(formula, None, None);
@@ -415,9 +427,8 @@ fn build_internal_document(doc: &crate::extraction::docx::parser::Document) -> I
                 }
             }
             crate::extraction::docx::parser::DocumentElement::Table(idx) => {
-                if current_list_numbering_id.is_some() {
+                while list_stack.pop().is_some() {
                     builder.end_list();
-                    current_list_numbering_id = None;
                 }
                 let table = &doc.tables[*idx];
                 if let Some(ref props) = table.properties
@@ -473,9 +484,8 @@ fn build_internal_document(doc: &crate::extraction::docx::parser::Document) -> I
                     continue;
                 }
 
-                if current_list_numbering_id.is_some() {
+                while list_stack.pop().is_some() {
                     builder.end_list();
-                    current_list_numbering_id = None;
                 }
                 let description = drawing.doc_properties.as_ref().and_then(|dp| dp.description.clone());
 
@@ -519,7 +529,7 @@ fn build_internal_document(doc: &crate::extraction::docx::parser::Document) -> I
         }
     }
 
-    if current_list_numbering_id.is_some() {
+    while list_stack.pop().is_some() {
         builder.end_list();
     }
 

--- a/crates/kreuzberg/tests/docx_formatting_test.rs
+++ b/crates/kreuzberg/tests/docx_formatting_test.rs
@@ -10,7 +10,17 @@ mod helpers;
 
 use helpers::{assert_non_empty_content, get_test_file_path};
 use kreuzberg::ExtractionConfig;
+use kreuzberg::core::config::OutputFormat;
 use kreuzberg::extract_file;
+
+/// `extract_file`'s default output format is `Plain` (raw text, no formatting markers);
+/// these tests assert on Markdown-specific markup, so they need to ask for it explicitly.
+fn markdown_config() -> ExtractionConfig {
+    ExtractionConfig {
+        output_format: OutputFormat::Markdown,
+        ..Default::default()
+    }
+}
 
 #[tokio::test]
 async fn test_docx_bold_rendered_as_markdown() {
@@ -19,7 +29,7 @@ async fn test_docx_bold_rendered_as_markdown() {
         return;
     }
 
-    let result = extract_file(&path, None, &ExtractionConfig::default())
+    let result = extract_file(&path, None, &markdown_config())
         .await
         .expect("Should extract DOCX");
 
@@ -38,7 +48,7 @@ async fn test_docx_italic_rendered_as_markdown() {
         return;
     }
 
-    let result = extract_file(&path, None, &ExtractionConfig::default())
+    let result = extract_file(&path, None, &markdown_config())
         .await
         .expect("Should extract DOCX");
 
@@ -57,7 +67,7 @@ async fn test_docx_hyperlink_rendered_as_markdown() {
         return;
     }
 
-    let result = extract_file(&path, None, &ExtractionConfig::default())
+    let result = extract_file(&path, None, &markdown_config())
         .await
         .expect("Should extract DOCX");
 
@@ -81,7 +91,7 @@ async fn test_docx_mixed_formatting_on_same_line() {
         return;
     }
 
-    let result = extract_file(&path, None, &ExtractionConfig::default())
+    let result = extract_file(&path, None, &markdown_config())
         .await
         .expect("Should extract DOCX");
 
@@ -101,7 +111,7 @@ async fn test_docx_title_rendered_as_h1() {
         return;
     }
 
-    let result = extract_file(&path, None, &ExtractionConfig::default())
+    let result = extract_file(&path, None, &markdown_config())
         .await
         .expect("Should extract DOCX");
 
@@ -120,7 +130,7 @@ async fn test_docx_heading_hierarchy() {
         return;
     }
 
-    let result = extract_file(&path, None, &ExtractionConfig::default())
+    let result = extract_file(&path, None, &markdown_config())
         .await
         .expect("Should extract DOCX");
 
@@ -172,7 +182,7 @@ async fn test_docx_bullet_list_rendered() {
         return;
     }
 
-    let result = extract_file(&path, None, &ExtractionConfig::default())
+    let result = extract_file(&path, None, &markdown_config())
         .await
         .expect("Should extract DOCX");
 
@@ -191,7 +201,7 @@ async fn test_docx_numbered_list_rendered() {
         return;
     }
 
-    let result = extract_file(&path, None, &ExtractionConfig::default())
+    let result = extract_file(&path, None, &markdown_config())
         .await
         .expect("Should extract DOCX");
 
@@ -210,7 +220,7 @@ async fn test_docx_nested_list_indentation() {
         return;
     }
 
-    let result = extract_file(&path, None, &ExtractionConfig::default())
+    let result = extract_file(&path, None, &markdown_config())
         .await
         .expect("Should extract DOCX");
 
@@ -252,7 +262,7 @@ async fn test_docx_tables_in_markdown_output() {
         return;
     }
 
-    let result = extract_file(&path, None, &ExtractionConfig::default())
+    let result = extract_file(&path, None, &markdown_config())
         .await
         .expect("Should extract DOCX");
 

--- a/crates/kreuzberg/tests/epub_markdown_headings_tests.rs
+++ b/crates/kreuzberg/tests/epub_markdown_headings_tests.rs
@@ -8,6 +8,7 @@
 #![cfg(feature = "office")]
 
 use kreuzberg::core::config::{ExtractionConfig, OutputFormat};
+use kreuzberg::core::pipeline::apply_output_format;
 use kreuzberg::extraction::derive::derive_extraction_result;
 use kreuzberg::extractors::EpubExtractor;
 use kreuzberg::plugins::DocumentExtractor;
@@ -100,7 +101,12 @@ async fn test_epub_markdown_output_keeps_headings() {
         .extract_bytes(&bytes, "application/epub+zip", &config)
         .await
         .expect("EPUB extraction should succeed");
-    let result = derive_extraction_result(doc, false, kreuzberg::OutputFormat::Plain);
+    let mut result = derive_extraction_result(doc, false, kreuzberg::OutputFormat::Markdown);
+    // `derive_extraction_result` always fills `content` with plain text; the pre-rendered
+    // Markdown lives in `formatted_content` until `apply_output_format` swaps it in — the
+    // step `run_pipeline` performs for every real extraction, skipped here since this test
+    // drives the extractor directly.
+    apply_output_format(&mut result, kreuzberg::OutputFormat::Markdown);
 
     assert!(
         result.processing_warnings.is_empty(),
@@ -134,7 +140,8 @@ async fn test_epub_djot_output_keeps_headings() {
         .extract_bytes(&bytes, "application/epub+zip", &config)
         .await
         .expect("EPUB extraction should succeed");
-    let result = derive_extraction_result(doc, false, kreuzberg::OutputFormat::Plain);
+    let mut result = derive_extraction_result(doc, false, kreuzberg::OutputFormat::Djot);
+    apply_output_format(&mut result, kreuzberg::OutputFormat::Djot);
 
     assert!(
         result.processing_warnings.is_empty(),


### PR DESCRIPTION
## What & why

Closes #5. Three distinct root causes behind the "formatting stripped from DOCX/EPUB/CSV" symptom — full writeup with commit citations in the [issue comment](https://github.com/kreuzberg-dev/kreuzberg-lts/issues/5#issuecomment-5557474508), summarized here:

**CSV — genuine regression, fixed in extraction code.** The header-value rendering (`Row N:` / `Header: Value` pairs, added in 9cc3ae018 for embedding/search quality) was silently dropped when CSV was migrated onto the generic `InternalDocument`+`Table` pipeline (the "document structure pipeline" migration, c24ab764f/1d53e6d90), falling back to a flat space-separated table dump.

**DOCX nested lists — genuine bug, fixed in extraction code.** Word nests list items under one `numId`, using `w:ilvl` to mark depth. `build_internal_document` only opened a new list container when `numId` changed and never looked at `ilvl` at all, so every nesting level under one list collapsed flat with no indentation.

**DOCX (9 of 10 failures) and EPUB (2 failures) — test bugs, extraction code already correct.** DOCX's tests asserted Markdown-specific formatting under `ExtractionConfig::default()` (`Plain`), left over from before `DocxExtractor` was refactored off an old implementation (9588953d8) that ignored `output_format` entirely, onto the shared pipeline architecture that correctly defaults to `Plain` like every other extractor. EPUB's tests called `derive_extraction_result` directly, skipping the `apply_output_format` step that swaps `formatted_content` into `content` in the real pipeline — so they always read back plain text regardless of the requested format.

## What changed

- `crates/kreuzberg/src/extractors/csv.rs` — restored `build_content_text()`, now emitted as a `Paragraph` element (the parsed table still goes straight into `doc.tables` for the `tables` field, just not as a rendered element, so it isn't rendered a second time).
- `crates/kreuzberg/src/extractors/docx.rs` — replaced the old `current_list_numbering_id: Option<i64>` / `current_list_ordered: bool` pair with a `list_stack: Vec<(numId, ilvl, ordered)>` that opens/closes nested list containers as `ilvl` changes, at every point lists used to be closed (paragraph with no text, heading, quote, table, drawing, end of document).
- `crates/kreuzberg/tests/docx_formatting_test.rs` — added a `markdown_config()` helper, applied to the 9 tests that needed `output_format: Markdown` explicitly.
- `crates/kreuzberg/tests/epub_markdown_headings_tests.rs` — added the missing `apply_output_format` call after `derive_extraction_result` in the two Markdown/Djot tests.
- `CHANGELOG.md` — new `[Unreleased]` section (none existed) with both fixes.

## How it was verified

```
cargo test -p kreuzberg --features office --no-fail-fast --test docx_formatting_test --test csv_embedding_quality --test epub_markdown_headings_tests
```

Used `office` rather than `full`: `full` pulls in `ocr`/`kreuzberg-tesseract`, which needs a system cmake/C++ toolchain to build Tesseract from source — unavailable in my environment and unrelated to this fix. `office` is the exact feature gate both `docx_formatting_test.rs` and `epub_markdown_headings_tests.rs` declare; `csv_embedding_quality.rs` has no feature gate at all.

- `csv_embedding_quality.rs`: 9/9 passed
- `docx_formatting_test.rs`: 16/16 passed
- `epub_markdown_headings_tests.rs`: 3/3 passed

Also ran the full `--lib` unit suite as a regression check on the `docx.rs` list-nesting change: 1601 passed, 4 pre-existing failures in `extraction::docx::tests::*page_break*` (a different module — page-boundary detection, untouched by this PR), confirmed identical on unmodified `main` via a baseline comparison before concluding they're unrelated.

`cargo fmt --check -p kreuzberg` is clean.

## Gates run

- [x] `cargo test` (scoped to `office` feature + the three affected test files, plus a full `--lib` regression pass)
- [x] `cargo fmt --check`
- [ ] Full `task test`/`task lint` (multi-language monorepo tooling) not run — no changes outside the Rust `kreuzberg` crate