### PR TITLE
fix: potential memory leak (generally hard to trigger)

### DIFF
--- a/crates/kreuzberg-tesseract/src/api.rs
+++ b/crates/kreuzberg-tesseract/src/api.rs
@@ -934,6 +934,17 @@ impl TesseractAPI {
         if vec_ptr.is_null() {
             return Err(TesseractError::NullPointerError);
         }
+
+        struct TextArrayGuard(*mut *mut c_char);
+        impl Drop for TextArrayGuard {
+            fn drop(&mut self) {
+                // SAFETY: `TessDeleteTextArray()` deallocates both the array
+                // and all contained strings.
+                unsafe { TessDeleteTextArray(self.0) };
+            }
+        }
+        let _text_array = TextArrayGuard(vec_ptr);
+
         let mut result = Vec::new();
         let mut i = 0;
         loop {
@@ -947,8 +958,6 @@ impl TesseractAPI {
             result.push(c_str.to_str()?.to_owned());
             i += 1;
         }
-        // SAFETY: TessDeleteTextArray() deallocates both the array and all contained strings:
-        unsafe { TessDeleteTextArray(vec_ptr) };
         Ok(result)
     }
 


### PR DESCRIPTION
## Related

<!-- Link issues or discussions if applicable -->

## Description

<!-- What does this PR do? -->

```rust
result.push(c_str.to_str()?.to_owned());
```

might fail if the input string is not in valid utf8 format, howevery unix allow the file's name to be out of utf8.
Therefore `vec_ptr` might get released on the error path.

TBA, this is very hard to trigger, fell free to close the PR.

## Checklist

- [x] CI passing
- [ ] Tests added where applicable
